### PR TITLE
Correcting help text pointing to Glossary

### DIFF
--- a/docs/developers/basic/entries.md
+++ b/docs/developers/basic/entries.md
@@ -25,7 +25,7 @@ An entry is a basic unit of user data. As a Holochain developer one of the most 
 
 *Quick reminder - A [Zome](https://developer.holochain.org/docs/glossary/#zome) is a module in a [DNA](https://developer.holochain.org/docs/glossary/#dna); the base of any [Holochain application (hApp)](https://developer.holochain.org/docs/glossary/#holochain-application-happ).*
 
-> You can always click `Core Concepts` and `Glossary` in the menu above to review the terms that you don't understand yet.
+> You can always click `Get Started` and `Glossary` in the menu above to review the terms that you don't understand yet.
 
 ## Creating an entry
 


### PR DESCRIPTION
I see some additional text was added pointing people to the glossary through the menu system.

So I tried it, and it's not there. It is under "Get Started", not "Core Concepts" although I guess if you're guessing that's where it should be then it probably should be, I mean how many people "Get Started" by reading through a Glossary? "Hey Steve, watchya doing over there?" "Oh, I'm learning Japanese, I thought I'd start by learning ALL THE WORDS". 

Anyway, might be an idea to actually check before committing, right?

I do like this though, I, like you, didn't know where it was in the menu system and, like you, didn't bother to go find it either so it is good to let the reader know how to access it. Providing of course you tell them the right place, and of course if the right place is in a logical place then that would help too.

Have a nice day ;)

sbp