### PR TITLE
Changes to entries gym documentation page post content->greeting_text…

### DIFF
--- a/docs/developers/basic/entries.md
+++ b/docs/developers/basic/entries.md
@@ -33,10 +33,8 @@ When you create an entry a few things will happen:
 
 1. Your data is validated locally _(we will learn how this works in later exercises)_
 2. The entry is written to your local [source chain](https://developer.holochain.org/docs/glossary/#source-chain) _(hence the 'chain' in 'Holochain')_
-3. If your [entry type](https://developer.holochain.org/docs/glossary/#entry-type) is marked as [public](https://developer.holochain.org/docs/glossary/#public-entry) like the one in this first exercise, your hApp will send it to some random people who are running the same hApp _(don't worry - soon we will talk about source chains, agents and why sending data to random people is not as scary as it may sound!)_
-4. The random people that received your data will validate your data using the same rules that were used in the first step. _(this is where the 'Holo', in Holochain comes from. To become an real entry, your entry has to be seen and validated by different people/agents. Just like a in a [hologram](http://www.displayhologram.co.uk/the-hologram/the-basics/), where different people can look at the same object from different angles and still agree on what they are seeing)_
-
-Luckily you do not have to worry about all of this yet. Since we are skipping all the validation steps in this exercise, creating an entry should just be as easy as in any other common application.
+3. If your [entry type](https://developer.holochain.org/docs/glossary/#entry-type) is marked as [public](https://developer.holochain.org/docs/glossary/#public-entry) like the one in this first exercise, your hApp will send it to some random people who are running the same hApp
+4. The random people that received your data will validate your data using the same rules that were used in the first step. _(this is where the 'Holo' in Holochain comes from. To become a real entry, your entry has to be seen and validated by different people/agents. Just like in a [hologram](http://www.displayhologram.co.uk/the-hologram/the-basics/), where different people can look at the same object from different angles and still agree on what they are seeing)_
 
 ## Try it!
 
@@ -126,7 +124,7 @@ In the `Entry Contents` you see three things:
 
 2. `entry_type` is specific to the Holochain technology underpinning our app. There are four types of entries: Agent, App, CapClaim, and CapGrant. For this exercise we limit our focus to [App entries](https://developer.holochain.org/docs/glossary/#app-entry).
 
-3. `greeting_text` is a custom field so you can give it a different name if you want to. You could add more fields as well, but for now one will do.
+3. `content` is the content of our custom field. You could add more fields as well, but for now one will do.
 
 ## Getting ready
 


### PR DESCRIPTION
**Notes for changes on entries gym doc page**

I'm creating this pull request to bring changes up to where I was previously before I create any in further sections down the page where I was before the content/greeting_text change and all the fluff with getting my OSX to compile the code. So now I can actually work through the examples and hence want to finish off what was done and move along, hope you understand as otherwise new issues will get mixed into old stuff. Anyway, here's what I've done this morning - I also did the branching and stuff locally so hopefully that all worked too, I guess it did as I'm here lol:

**Section: Creating an entry**

_In list item 3:_

“_(don't worry - soon we will talk about source chains, agents and why sending data to random people is not as scary as it may sound!)_”

Removed this as we’re actually explaining it in the next point with the hologram example, so before the reader has chance to worry about it we’ve explained the reason - I think anything further explanatory here will just confuse - the hologram example is great as everyone can relate to that, coder or not! (A picture worth a thousand words etc., even better for a holographic one eh hah!)

_In list item 4:_

Just some small grammatical corrections. I love the hologram example, it’s perfect!

_Last paragraph:_

“Luckily you do not have to worry about all of this yet.” 

First thoughts when reading this hence why removed as believe does not add value and with extra hologram text in now it’s already quite text heavy so let’s just move on to the let’s do it!

- We’ve already stated what we’re going to deal with, my brain has moved on, I don’t need it re-iterated to me and now I’m thinking about how I’m going to worry about it later ;) So I don’t see the point in it being here, I think it’s text for the sake of text.

“Since we are skipping all the validation steps in this exercise, creating an entry should just be as easy as in any other common application.”

- If I don’t find this easy (perhaps I’ve never even done this before) then this is putting pressure on me.
- If you read this again, it actually says other common applications don’t validate…

**Section: Try it!**

3. ‘greeting_text’ is a custom field so you can give it a different name if you want to. You could add more fields as well, but for now one will do.

Now I understand what’s going on here, this needs correcting for a start and also I believe changing because we no longer have the confusion about content being the field name as well as the name of the key here. So after some thought, I settled on:

3. ‘content’ is the content of our custom field. You could add more fields as well, but for now one will do.

I removed the explanation about being able to change the name of a custom field. I think that was only in there because of the naming issue we had, and whilst yes the reader does need to know that custom fields can be called anything, I’m not so sure this is the right place so removed it and it sounds ok. 

This makes more sense to me now, any further explanation will confuse I think - I tried putting it in and it just got way too fluffy and I felt like “yeah I know you can call fields anything dude, what’s your problem lol let’s get on with it”. 

Even just putting “`content` is the content of our custom field `greeting_text`” started to make it more complicated than it needs to be. Anyways… hopefully that’s now put all this one to rest… onwards and upwards!


