### PR TITLE
Fixing broken link & capitalising Holochain

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,3 +1,3 @@
 # Concepts ||1
 
-Start exploring how holochain works by moving on to the [DHT](/concepts/DHT) page.
+Start exploring how Holochain works by moving on to the [DHT](/concepts/dht/) page.


### PR DESCRIPTION
I can't help it. I thought right, finally after months I've time to look at the gym again before devcamp and within 5 minutes I find a broken link ;)

I saw a link to the 'concepts' section so clicked on it, it said start from the DHT section, the link broke, seems it was upper case so this fixes that.

Also noticed 'holochain' so thought as was discussed previously, Holochain should always be capitalised.

I wonder how much I'll learn this time, hopefully more than I have so far... at least I have a deadline to learn with devcamp coming up soon - very excited, a bit nervous but reckon my brain can take it ;)

Anyway, nice to be back, been busy with business stuff, so fingers crossed on that front!