### PR TITLE
fix url pointing to wrong excercise

### DIFF
--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -21,7 +21,7 @@ This will give you time to get used to the Rust syntax and see some [HDK](https:
 
 **Finally**
 
-You can hit the gym and start your [first exercise](/developers/basic/entries/).
+You can hit the gym and start your [first exercise](/developers/basic/zome-functions/).
 
 *Practice, rest, eat healthy and repeat.*  
 *Good luck!*  


### PR DESCRIPTION
If I'm not mistaken the first excercise is the `zome-functions` and not the `entries`, or is it on purpose linking to the `entries` excecise? 🤔