### PR TITLE
Fix typo and add link

### DIFF
--- a/docs/developers/basic/entries.md
+++ b/docs/developers/basic/entries.md
@@ -283,3 +283,4 @@ thread 'holochain-tokio-thread' panicked at 'TODO: DnaError
 (ZomeNotFound("Zome \'exercise\' not found"))',
 /build/source/crates/holochain/src/core/ribosome.rs:336:14
 ```
+**[Next >](/developers/basic/hashes/)**

--- a/docs/developers/basic/zome-functions.md
+++ b/docs/developers/basic/zome-functions.md
@@ -229,7 +229,7 @@ You will in fact have created your very first decentralized, agent centric, boun
 1. Go to the `developer-exercises`.
 2. Enter the nix-shell: `nix-shell`.
    _you should run this in the folder containing the default.nix file_  
-3. Go to folder with the exercise `basic/0.zome-functions/exercise`.
+3. Go to folder with the exercise `1.basic/0.zome-functions/exercise`.
 4. Inside `zome/exercise/src/lib.rs`:
    - Import the HDK library and functions.
    - Add the `#[hdk_extern]` macro in the necessary functions.


### PR DESCRIPTION
I noticed two mistakes in the documentation, a typo and a missing link.